### PR TITLE
fix-it(Cloud Monitoring Api): Change the quick start documentation.

### DIFF
--- a/monitoring/cloud-client/src/main/java/com/example/monitoring/QuickstartSample.java
+++ b/monitoring/cloud-client/src/main/java/com/example/monitoring/QuickstartSample.java
@@ -55,7 +55,7 @@ public class QuickstartSample {
         TimeInterval.newBuilder()
             .setEndTime(Timestamps.fromMillis(System.currentTimeMillis()))
             .build();
-    TypedValue value = TypedValue.newBuilder().setDoubleValue(123.45).build();
+    TypedValue value = TypedValue.newBuilder().setDoubleValue(3.14).build();
     Point point = Point.newBuilder().setInterval(interval).setValue(value).build();
 
     List<Point> pointList = new ArrayList<>();
@@ -68,15 +68,16 @@ public class QuickstartSample {
     metricLabels.put("store_id", "Pittsburg");
     Metric metric =
         Metric.newBuilder()
-            .setType("custom.googleapis.com/stores/daily_sales")
+            .setType("custom.googleapis.com/my_metric")
             .putAllLabels(metricLabels)
             .build();
 
     // Prepares the monitored resource descriptor
     Map<String, String> resourceLabels = new HashMap<String, String>();
-    resourceLabels.put("project_id", projectId);
+    resourceLabels.put("instance_id", "1234567890123456789");
+    resourceLabels.put("zone", "us-central1-f");
     MonitoredResource resource =
-        MonitoredResource.newBuilder().setType("global").putAllLabels(resourceLabels).build();
+        MonitoredResource.newBuilder().setType("gce_instance").putAllLabels(resourceLabels).build();
 
     // Prepares the time series request
     TimeSeries timeSeries =


### PR DESCRIPTION
- Change the quick start metric to `custom.googleapis.com/my_metric` 
- Change the type to "gce_instance".

Justification: Cloud monitoring api team discourage using "global" resource type for custom metric, and to align the sample, I change the metric type also.

Fixes #issue

> It's a good idea to open an issue first for discussion.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [x] Please **merge** this PR for me once it is approved.
